### PR TITLE
Fix CLI call

### DIFF
--- a/packages/migration/CHANGELOG.md
+++ b/packages/migration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.4 - 2020-06-15
+
+- Fix the CLI call
+
 ## 0.1.3 - 2020-06-09
 
 - Fixed a bug related to unran migration from merged git branches timeline.

--- a/packages/migration/cli.ts
+++ b/packages/migration/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { runMigrations, createMigrationFile } from "./index";
 import { getConfig } from "./utils/getConfig";
 

--- a/packages/migration/package.json
+++ b/packages/migration/package.json
@@ -50,5 +50,5 @@
     "migration": "dist/runCli.js"
   },
   "types": "dist/index.d.ts",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/packages/migration/runCli.ts
+++ b/packages/migration/runCli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { runCLI } from "./cli";
 
 runCLI();


### PR DESCRIPTION
## Detailed description

This PR fixes the use of migrations with the CLI.
The bug was that the script could not be called as it lacked the shebang.

## Related Story

[ch-3794]