### PR TITLE
Add back Tracer type

### DIFF
--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.1 - 2020-12-29
+
+- Added back a `Tracer` type.
+
 ## 0.5.0 - 20200-12-22
 
 - Add a `createRootSpan` function that will start a trace when the plugins can't be loaded (for instance, for a Next application).

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -57,5 +57,5 @@
     "test": "jest"
   },
   "types": "dist/index.d.ts",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/packages/tracing/tracer.ts
+++ b/packages/tracing/tracer.ts
@@ -58,7 +58,13 @@ export function startTracer(options: TracingConfig, logger?: Logger): void {
 
 type SpanCallback<T> = (span: Span) => Promise<T>;
 
-class Tracer {
+export interface Tracer {
+  createRootSpan: (name: string) => Span;
+  createSpan: (name: string) => Span;
+  span: <T>(name: string, callback: SpanCallback<T>) => Promise<T>;
+}
+
+class TracerImpl implements Tracer {
   private static instance: Tracer;
   private tracer: OpenTelemetryTracer;
   private constructor() {
@@ -67,11 +73,11 @@ class Tracer {
   private rootSpan?: OpenTelemetrySpan;
 
   static getInstance(): Tracer {
-    if (!Tracer.instance) {
-      Tracer.instance = new Tracer();
+    if (!TracerImpl.instance) {
+      TracerImpl.instance = new TracerImpl();
     }
 
-    return Tracer.instance;
+    return TracerImpl.instance;
   }
 
   createRootSpan(name: string): Span {
@@ -114,7 +120,7 @@ class Tracer {
 }
 
 export function getTracer(): Tracer {
-  return Tracer.getInstance();
+  return TracerImpl.getInstance();
 }
 
 function spanFactory(otSpan: OpenTelemetrySpan): Span {


### PR DESCRIPTION
## Description

This PR readds a `Tracer` type since the previous version did not export the `Tracer` class anymore.
As I don't want to allow someone to use the class directly, this `Tracer` type is an interface and the `Tracer` class has been renamed `TracerImpl`.



