### PR TITLE
Avoid creating several tracers

### DIFF
--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.6.1 - 2021-01-04
+
+- Calling `startTracer` several times will not register several tracers anymore.
+
 ## 0.6.0 - 2020-12-31
 
 - The exported `Span` interface now exposes `addEvent` to add events to spans.

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -57,5 +57,5 @@
     "test": "jest"
   },
   "types": "dist/index.d.ts",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/packages/tracing/tracer.ts
+++ b/packages/tracing/tracer.ts
@@ -34,7 +34,12 @@ const provider: BasicTracerProvider = new NodeTracerProvider({
   },
 });
 
+let isTracerStarted = false;
+
 export function startTracer(options: TracingConfig, logger?: Logger): void {
+  if (isTracerStarted) {
+    return;
+  }
   const collector = new ZipkinExporter({
     serviceName: options.serviceName,
     url: options.url,
@@ -48,6 +53,8 @@ export function startTracer(options: TracingConfig, logger?: Logger): void {
   contextManager.enable();
 
   provider.register({ contextManager });
+
+  isTracerStarted = true;
 
   if (logger) {
     logger.log("tracing initialized", {


### PR DESCRIPTION
## Description

This PR makes a little change necessary for using tracing inside next on dev mode: the compilation didn't reset the tracer.
Meaning that every time the code recompiles, we have a new tracer and every spans is recorded N times.