### PR TITLE
Database with extended types

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0 - 2021-01-07
+
+- `DatabaseQueryRunner` is now a union type of `DatabaseQueryRunnerWithTracing`, `DatabaseQueryRunnerWithoutTracing`, `DatabaseQueryRunnerSandbox`.
+
 ## 0.2.0 - 2021-01-06
 
 - Added a new Sandbox mode for testing purposes.

--- a/packages/database/database.ts
+++ b/packages/database/database.ts
@@ -21,8 +21,14 @@ interface DatabaseBaseQueryRunner {
   transaction: (txFunc: TransactionFunction) => Promise<any>;
 }
 
-export interface DatabaseQueryRunner extends DatabaseBaseQueryRunner {
-  _type?: "DatabaseQueryRunner";
+export type DatabaseQueryRunner =
+  | DatabaseQueryRunnerWithoutTracing
+  | DatabaseQueryRunnerSandbox
+  | DatabaseQueryRunnerWithTracing;
+
+export interface DatabaseQueryRunnerWithTracing
+  extends DatabaseBaseQueryRunner {
+  _type?: "DatabaseQueryRunnerWithTracing";
 }
 
 export interface DatabaseQueryRunnerWithoutTracing
@@ -78,7 +84,7 @@ function queryRunner(
   pool: Pool,
   tracer: Tracer,
   txClient: undefined | PoolClient = undefined,
-): DatabaseQueryRunner {
+): DatabaseQueryRunnerWithTracing {
   const withoutTracing = queryRunnerWithoutTracing(pool, txClient);
   return {
     close: async (): Promise<void> => {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -45,5 +45,5 @@
     "test": "jest"
   },
   "types": "dist/index.d.ts",
-  "version": "0.0.0-experimental-af92ca1"
+  "version": "0.2.1"
 }


### PR DESCRIPTION
This PR fixes the incompatibility between the different `DatabaseQueryRunner` types