### PR TITLE
Automatically load modules for tracing

### DIFF
--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.6.2 - 2021-01-07
+
+- Disable explicitely `pg` and `pg-pool` modules.
+- Add `http` and `https` modules to the dependencies, to have them loaded automatically.
+
 ## 0.6.1 - 2021-01-04
 
 - Calling `startTracer` several times will not register several tracers anymore.

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -8,6 +8,8 @@
     "@opentelemetry/exporter-collector": "0.14.0",
     "@opentelemetry/exporter-zipkin": "0.14.0",
     "@opentelemetry/node": "0.14.0",
+    "@opentelemetry/plugin-http": "0.14.0",
+    "@opentelemetry/plugin-https": "0.14.0",
     "@opentelemetry/tracing": "0.14.0"
   },
   "devDependencies": {
@@ -57,5 +59,5 @@
     "test": "jest"
   },
   "types": "dist/index.d.ts",
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/packages/tracing/tracer.ts
+++ b/packages/tracing/tracer.ts
@@ -23,6 +23,8 @@ const provider: BasicTracerProvider = new NodeTracerProvider({
   logLevel: LogLevel.INFO,
   plugins: {
     express: { enabled: false },
+    pg: { enabled: false },
+    "pg-pool": { enabled: false },
     http: {
       enabled: true,
       path: "@opentelemetry/plugin-http",

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,29 @@
     require-in-the-middle "^5.0.0"
     semver "^7.1.3"
 
+"@opentelemetry/plugin-http@0.14.0", "@opentelemetry/plugin-http@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/plugin-http/-/plugin-http-0.14.0.tgz#5c5ac23bd3a5cbd8891fce857d52a86bb0dbf51c"
+  integrity sha512-j6VHSotl+geN+znYgGgn/GohTAirAtHum8Zpc52VZ/WQCrNfHcmEf4NYaGCuz5tW2EgmbH+66iDM/lgNadQuQg==
+  dependencies:
+    "@opentelemetry/api" "^0.14.0"
+    "@opentelemetry/core" "^0.14.0"
+    "@opentelemetry/semantic-conventions" "^0.14.0"
+    semver "^7.1.3"
+    shimmer "^1.2.1"
+
+"@opentelemetry/plugin-https@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/plugin-https/-/plugin-https-0.14.0.tgz#60a0db56339de497b35aaae0de91b10ecff9b0ea"
+  integrity sha512-FyT3iaEO9CdGu1EeIe+JmAwfoYwjG9GtHiyWSovFEKO/0OLQLrXA2AQDgltOeelu/snPGB2MF92iPqbpfVdhHw==
+  dependencies:
+    "@opentelemetry/api" "^0.14.0"
+    "@opentelemetry/core" "^0.14.0"
+    "@opentelemetry/plugin-http" "^0.14.0"
+    "@opentelemetry/semantic-conventions" "^0.14.0"
+    semver "^7.1.3"
+    shimmer "^1.2.1"
+
 "@opentelemetry/resources@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-0.14.0.tgz#e89378931b4e02d4b6fb526d237d9594db2bb68a"
@@ -6954,6 +6977,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shimmer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
This PR try to get rid of the `pg` and `pg-pool` warning when we're not using them (not sure it will work though).
It also re-add the dependencies on the `http` and `https` plugin packages because we need to import them explicitely somewhere.