### PR TITLE
Addition of the `id` field in the `AlertMessage` type

### DIFF
--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.11.3 - 2021-03-19
+
+- Added an `id` field in the `AlertMessage` type to help with filtering.
+
 ## 0.11.2 - 2021-03-11
 
 - The `createApp` utility function for Express now automatically sends a 404 JSON formatted response when the `Accept` header of the request is explicitly set as `application/json`.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -598,7 +598,7 @@ await deleteServerSideCookie(response, "cookie-name");
 
 Used to set a cookie on the server side.
 
-Alert message data structure: `{text: string, expiresAt: number}`.
+Alert message data structure: `{id: string, text: string, expiresAt: number}`.
 
 This function requires as input:
 
@@ -606,7 +606,11 @@ This function requires as input:
 - A **list** of alert messages — even you only want to set a single alert message.
 
 ```ts
-const alertMessage = { text: "foo", expiresAt: Date.now() + 300000 };
+const alertMessage = {
+  id: "e308b694-7fc1-49dd-9a6e-0cf1d0fcc00c",
+  text: "foo",
+  expiresAt: Date.now() + 300000,
+};
 
 setAlertMessagesCookie(response, [alertMessage]);
 ```
@@ -619,5 +623,5 @@ const serializedAlertMessages = await getServerSideCookies(request, {
   cookieName: "alert-messages",
 });
 
-JSON.parse(serializedAlertMessages); // { text: "foo", expiresAt: 1614939460723 }
+JSON.parse(serializedAlertMessages); // { id: "e308b694-7fc1-49dd-9a6e-0cf1d0fcc00c", text: "foo", expiresAt: 1614939460723 }
 ```

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -71,5 +71,5 @@
     ]
   },
   "types": "dist/index.d.ts",
-  "version": "0.0.0-experimental-3606cd8"
+  "version": "0.11.3"
 }

--- a/packages/web/src/typings/utils.ts
+++ b/packages/web/src/typings/utils.ts
@@ -12,6 +12,7 @@ type GetServerSideCookiesParams = {
 };
 
 type AlertMessage = {
+  id: string;
   text: string;
   expiresAt: number;
 };

--- a/packages/web/tests/utils.test.ts
+++ b/packages/web/tests/utils.test.ts
@@ -172,6 +172,7 @@ describe("Server side cookies", () => {
       );
 
       const newCookie = {
+        id: "5ae024cb-9442-4f84-867d-b77ac549594f",
         text: "This is the second cookie",
         expiresAt: currentTime,
       };
@@ -180,7 +181,7 @@ describe("Server side cookies", () => {
       expect(mockedResponse.getHeader("set-cookie")).toBeInstanceOf(Array);
       expect(mockedResponse.getHeader("set-cookie")).toStrictEqual([
         "previous-cookie=%22This%20needs%20to%20be%20concatenated%22; Max-Age=86400; Path=/",
-        `alert-messages=%5B%7B%22text%22%3A%22This%20is%20the%20second%20cookie%22%2C%22expiresAt%22%3A${currentTime}%7D%5D; Max-Age=86400; Path=/`,
+        `alert-messages=%5B%7B%22id%22%3A%225ae024cb-9442-4f84-867d-b77ac549594f%22%2C%22text%22%3A%22This%20is%20the%20second%20cookie%22%2C%22expiresAt%22%3A${currentTime}%7D%5D; Max-Age=86400; Path=/`,
       ]);
     });
 
@@ -192,16 +193,18 @@ describe("Server side cookies", () => {
 
       setAlertMessagesCookie(mockedResponse, [
         {
+          id: "17c8948d-d2fc-43e4-95cd-0698524a8f77",
           text: "foo",
           expiresAt: currentTime,
         },
         {
+          id: "da947d28-8ea2-41d1-84eb-495e7e79de18",
           text: "bar",
           expiresAt: currentTime,
         },
       ]);
       expect(mockedResponse.getHeader("set-cookie")).toBe(
-        `alert-messages=%5B%7B%22text%22%3A%22foo%22%2C%22expiresAt%22%3A${currentTime}%7D%2C%7B%22text%22%3A%22bar%22%2C%22expiresAt%22%3A${currentTime}%7D%5D; Max-Age=86400; Path=/`,
+        `alert-messages=%5B%7B%22id%22%3A%2217c8948d-d2fc-43e4-95cd-0698524a8f77%22%2C%22text%22%3A%22foo%22%2C%22expiresAt%22%3A${currentTime}%7D%2C%7B%22id%22%3A%22da947d28-8ea2-41d1-84eb-495e7e79de18%22%2C%22text%22%3A%22bar%22%2C%22expiresAt%22%3A${currentTime}%7D%5D; Max-Age=86400; Path=/`,
       );
     });
   });
@@ -217,6 +220,7 @@ describe("Server side cookies", () => {
 
       setAlertMessagesCookie(mockedResponse, [
         {
+          id: "25c8c95c-0b7c-4b30-8d1e-e93e450dea32",
           text: "foo",
           expiresAt: currentTime,
         },


### PR DESCRIPTION
## Description

This PR aims at adding an `id` field to the `AlertMessage` type, to help the filtering out process when said alert message has been rendered.

## How Has This Been Tested?

I've updated the related tests, and published an experimental branch to test it inside `Connect.Account`.

## Types of changes

<!--- What types of changes does your code introduce? Stroke -->
- [ ] Chore (non-breaking change which refactors / improves the existing code base)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to 
  change)

## Checklist:

<!--- Go over all the following points, and replace the `:red_circle:` in all -->
<!--- the lines with a :white_check_mark: when relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're -->
<!--- here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change requires a change to a package version.
- [x] I have updated the `package.json` version accordingly.
- [x] I have updated the `CHANGELOG.md` version accordingly.
- [x] I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/node-web-libraries/blob/master/CONTRIBUTING.md
