### PR TITLE
bump-all-packages

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,6 +6,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "version": "0.6.2",
+  "files": [
+    "dist/**/*"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/fewlinesco/node-web-libraries",
@@ -49,8 +52,5 @@
       "@fewlines/eslint-config/node",
       "@fewlines/eslint-config/typescript"
     ]
-  },
-  "files": [
-    "dist/**/*"
-  ]
+  }
 }

--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.4 - 2022-04-25
+
+- [fix] add repository key in `package.json` to trigger the changelog in `dependabot`'s PRs description
+
 ## 0.1.3 - 2022-04-15
 
 - [fix] move all dependencies from `devDependencies` to `dependencies` to make `@fwl/logging` work in any project.

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,30 @@
 {
   "author": "Fewlines",
   "description": "Logging part of Fewlines Web Libraries",
+  "types": "dist/index.d.ts",
+  "version": "0.1.4",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "name": "@fwl/logging",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fewlinesco/node-web-libraries",
+    "directory": "packages/logging"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prelint": "prettier --trailing-comma all --write './**/*.md'",
+    "lint": "eslint --ext ts --ignore-pattern dist .",
+    "prebuild": "yarn clean",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn test && yarn lint",
+    "preversion": "yarn lint",
+    "test": "jest"
+  },
   "dependencies": {
     "@types/logfmt": "1.2.1",
     "@types/node": "15.6.1",
@@ -26,24 +50,5 @@
       "@fewlines/eslint-config/node",
       "@fewlines/eslint-config/typescript"
     ]
-  },
-  "files": [
-    "dist/**/*"
-  ],
-  "license": "MIT",
-  "main": "dist/index.js",
-  "name": "@fwl/logging",
-  "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist",
-    "prelint": "prettier --trailing-comma all --write './**/*.md'",
-    "lint": "eslint --ext ts --ignore-pattern dist .",
-    "prebuild": "yarn clean",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn test && yarn lint",
-    "preversion": "yarn lint",
-    "test": "jest"
-  },
-  "types": "dist/index.d.ts",
-  "version": "0.1.3"
+  }
 }

--- a/packages/oauth2/CHANGELOG.md
+++ b/packages/oauth2/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-All notable changes to this project will be documented in this file.
+## [0.2.0] - 2022-04-25
+
+- [fix] add repository key in `package.json` to trigger the changelog in `dependabot`'s PRs description
 
 ## [0.1.9] - 2022-04-15
 

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -1,6 +1,30 @@
 {
+  "name": "@fwl/oauth2",
   "author": "Fewlines",
   "description": "OAuth2 part of Fewlines Web Libraries",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "version": "0.2.0",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fewlinesco/node-web-libraries",
+    "directory": "packages/oauth2"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prelint": "prettier --trailing-comma all --write './**/*.md'",
+    "lint": "eslint --ext ts --ignore-pattern dist .",
+    "prebuild": "yarn clean",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn lint",
+    "preversion": "yarn lint",
+    "test": "jest"
+  },
   "dependencies": {
     "@types/jsonwebtoken": "8.5.0",
     "@types/node-fetch": "2.5.7",
@@ -32,34 +56,11 @@
       "@fewlines/eslint-config/typescript"
     ]
   },
-  "files": [
-    "dist/**/*"
-  ],
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "dist/"
     ]
-  },
-  "license": "MIT",
-  "main": "dist/index.js",
-  "name": "@fwl/oauth2",
-  "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist",
-    "prelint": "prettier --trailing-comma all --write './**/*.md'",
-    "lint": "eslint --ext ts --ignore-pattern dist .",
-    "prebuild": "yarn clean",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn lint",
-    "preversion": "yarn lint",
-    "test": "jest"
-  },
-  "types": "dist/index.d.ts",
-  "version": "0.1.9",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/fewlinesco/node-web-libraries/tree/master/packages/oauth2"
   }
 }

--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.10.6 - 2022-04-15
+
+- [fix] add repository key in `package.json` to trigger the changelog in `dependabot`'s PRs description
+
 ## 0.10.5 - 2022-04-15
 
 - [fix] move all dependencies from `devDependencies` to `dependencies` to make `@fwl/tracing` work in any project.

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,31 @@
 {
+  "name": "@fwl/tracing",
   "author": "Fewlines",
   "description": "Tracing part of Fewlines Web Libraries",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "version": "0.10.6",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fewlinesco/node-web-libraries",
+    "directory": "packages/tracing"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
+    "prelint": "prettier --trailing-comma all --write './**/*.md'",
+    "lint": "eslint --ext ts --ignore-pattern dist .",
+    "prebuild": "yarn clean",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn lint",
+    "preversion": "yarn lint",
+    "test": "jest"
+  },
   "dependencies": {
     "@fwl/logging": "0.1.2",
     "@opentelemetry/api": "1.0.2",
@@ -37,31 +62,11 @@
       "@fewlines/eslint-config/typescript"
     ]
   },
-  "files": [
-    "dist/**/*"
-  ],
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "dist/"
     ]
-  },
-  "license": "MIT",
-  "main": "dist/index.js",
-  "name": "@fwl/tracing",
-  "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist",
-    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
-    "prelint": "prettier --trailing-comma all --write './**/*.md'",
-    "lint": "eslint --ext ts --ignore-pattern dist .",
-    "prebuild": "yarn clean",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn lint",
-    "preversion": "yarn lint",
-    "test": "jest"
-  },
-  "types": "dist/index.d.ts",
-  "version": "0.10.5"
+  }
 }

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.14.1 - 2022-04-25
+
+- [fix] add repository key in `package.json` to trigger the changelog in `dependabot`'s PRs description
+
 ## 0.14.0 - 2022-04-15
 
 - [fix] move all dependencies from `devDependencies` to `dependencies` to make `@fwl/web` work in any project.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,31 @@
 {
+  "name": "@fwl/web",
   "author": "Fewlines",
   "description": "Web part of Fewlines Web Libraries",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "version": "0.14.1",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fewlinesco/node-web-libraries",
+    "directory": "packages/web"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prelint": "prettier --trailing-comma all --write './**/*.md'",
+    "lint": "eslint --ext ts --ignore-pattern dist .",
+    "prebuild": "yarn clean",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn lint",
+    "preversion": "yarn lint",
+    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
+    "test": "jest --runInBand"
+  },
   "dependencies": {
     "@fwl/logging": "0.1.2",
     "@fwl/tracing": "0.10.0",
@@ -46,31 +71,11 @@
       "@fewlines/eslint-config/typescript"
     ]
   },
-  "files": [
-    "dist/**/*"
-  ],
-  "license": "MIT",
-  "main": "dist/index.js",
-  "name": "@fwl/web",
-  "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist",
-    "prelint": "prettier --trailing-comma all --write './**/*.md'",
-    "lint": "eslint --ext ts --ignore-pattern dist .",
-    "prebuild": "yarn clean",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn lint",
-    "preversion": "yarn lint",
-    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
-    "test": "jest --runInBand"
-  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "dist/"
     ]
-  },
-  "types": "dist/index.d.ts",
-  "version": "0.14.0"
+  }
 }


### PR DESCRIPTION
## Description

This PR bumps all packages (but database, that was the test before bumping the others) according to what have been done [here](https://github.com/fewlinesco/node-web-libraries/pull/134)

## Related Issue

https://github.com/fewlinesco/node-web-libraries/pull/134

## Motivation and Context

Make our PR more readable with dependabot showing our release notes in its PRs.

## How Has This Been Tested?

It has been tester [here](https://github.com/fewlinesco/sparta-monorepo/pull/1166)

## Types of changes

- [x] Chore (non-breaking change which refactors / improves the existing code base)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to 
  change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to a package version.
- [x] I have updated the `package.json` version accordingly.
- [x] I have updated the `CHANGELOG.md` version accordingly.
- [x] I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/node-web-libraries/blob/master/CONTRIBUTING.md
