### PR TITLE
Fix naming for docker releases

### DIFF
--- a/bin/build-and-push.sh
+++ b/bin/build-and-push.sh
@@ -23,7 +23,7 @@ gitCommit=${4:?"git commit SHA is required as fourth argument"};
 gitBranch=${3:?"git branch is required as third argument"};
 
 gitShortCommit=$(echo $CIRCLE_SHA1 | cut -c -7)
-releaseName=$(echo ${gitBranch} | sed 's/^\(CU-[[:alnum:]]*\).*/\1/')
+releaseName=$(echo ${gitBranch} | sed 's/^\(CU-[[:alnum:]]*\).*/\1/' | sed 's/\//-/g')
 
 environment=$(_appEnvironment $gitBranch)
 dockerTag=${environment}_${gitCommit}

--- a/packages/oauth2/CHANGELOG.md
+++ b/packages/oauth2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.2.2] - 2022-05-02
+
+- Bump node-fetch to the latest version of the 2.x branch
+
 ## [0.2.1] - 2022-05-02
 
 - Bump all dependencies

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -31,7 +31,7 @@
     "@types/node-fetch": "2.6.1",
     "@types/node-jose": "1.1.10",
     "jsonwebtoken": "8.5.1",
-    "node-fetch": "2.6.1",
+    "node-fetch": "2.6.7",
     "node-jose": "2.1.1"
   },
   "devDependencies": {

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "files": [
     "dist/**/*"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,6 +318,41 @@
   resolved "https://registry.yarnpkg.com/@fewlines/eslint-config/-/eslint-config-3.1.2.tgz#14e9bbc8c6027a118e1fc4135827b2f028dfc87f"
   integrity sha512-JDSQ4FR4MDf6KaOSLinP+9S212BFRiYKo2GTk9OfjzJg+5CXajIilJKfpehIiCnzi2Ptcj7+Xr88njOspPid2Q==
 
+"@fwl/logging@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@fwl/logging/-/logging-0.1.2.tgz#dc462f4e98c3db5dcd767ebafb06824fde1694ce"
+  integrity sha512-RUq7aKMuPDD9HlIhyoNfD2W361B7xxFJf7Uo4txVufqeZjy6GdP93FHxwX+gB7InreZr8QKFmAwoA8ZWu8zdyA==
+  dependencies:
+    logfmt "1.3.2"
+
+"@fwl/logging@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fwl/logging/-/logging-0.1.4.tgz#7a20cdaa5fa8ea616527096f47662fb27466c875"
+  integrity sha512-Ygz4Tpd1iVOOeUAU4NJDQSabj/icJ6jtqmERtC03UgfPDm8dS9yIyAeZPkFUf/Zhg5QV0ZKkUiVC8BMyS4hR9w==
+  dependencies:
+    "@types/logfmt" "1.2.1"
+    "@types/node" "15.6.1"
+    logfmt "1.3.2"
+
+"@fwl/tracing@0.10.6":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@fwl/tracing/-/tracing-0.10.6.tgz#05143ade3c0cf9571f452884fd1a9712b9fe919e"
+  integrity sha512-PCLXB0Ez5ICdi73QpzKtGKKwbdKgh4Zk3R27wG7+zYggNqLcbkaN61V18+hpTWySPhMcf8dl25IUP/Xy3KzmUA==
+  dependencies:
+    "@fwl/logging" "0.1.2"
+    "@opentelemetry/api" "1.0.2"
+    "@opentelemetry/context-async-hooks" "0.25.0"
+    "@opentelemetry/core" "0.25.0"
+    "@opentelemetry/exporter-collector" "0.25.0"
+    "@opentelemetry/exporter-zipkin" "0.25.0"
+    "@opentelemetry/node" "0.24.0"
+    "@opentelemetry/plugin-http" "0.18.2"
+    "@opentelemetry/plugin-https" "0.18.2"
+    "@opentelemetry/resources" "0.25.0"
+    "@opentelemetry/semantic-conventions" "0.25.0"
+    "@opentelemetry/tracing" "0.24.0"
+    "@types/node" "16.7.2"
+
 "@hapi/b64@5.x.x":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/b64/-/b64-5.0.0.tgz#b8210cbd72f4774985e78569b77e97498d24277d"
@@ -681,6 +716,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.25.0.tgz#3b996842c8043068da4d11a6e96960e757ad6be9"
   integrity sha512-9T0c9NQAEGRujUC7HzPa2/qZ5px/UvB2sfSU5CAKFRrAlDl2gn25B0oUbDqSRHW/IG1X2rnQ3z2bBQkJyJvE4g==
 
+"@opentelemetry/api@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.2.tgz#921e1f2b2484b762d77225a8a25074482d93fccf"
+  integrity sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww==
+
 "@opentelemetry/api@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.1.0.tgz#563539048255bbe1a5f4f586a4a10a1bb737f44a"
@@ -695,6 +735,11 @@
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.24.0.tgz#d726cda794f8057c63631d111c7375744ed1cc75"
   integrity sha512-Db8AgMByBEFKLJGSUBlNq4Un/Tqzj5W0hTxx3hIic8DvBwqbvUvkMGuiQYLKE2Ay21cLYMT01xK4TEKz0OxADw==
+
+"@opentelemetry/context-async-hooks@0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.25.0.tgz#35e0552a900a1db065dd9d3996729486fe21f78a"
+  integrity sha512-XNjlBalbN82qCfkgPpof6g3oU/LZoyoGGrluA+cy4AKWjJ9FdEZqKwX2p2WHxEuWm8TrHh5HxqEXH5OH2o/5tw==
 
 "@opentelemetry/context-async-hooks@1.2.0":
   version "1.2.0"
@@ -742,6 +787,16 @@
     "@opentelemetry/resources" "0.25.0"
     "@opentelemetry/sdk-metrics-base" "0.25.0"
     "@opentelemetry/sdk-trace-base" "0.25.0"
+
+"@opentelemetry/exporter-zipkin@0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.25.0.tgz#355b884774338ea435425d6c29d51d791c609641"
+  integrity sha512-tdVHdA0vrsQm/+OEdLiZtHUfuIcU+NBBntM+IDfrRqecHlvm/NnOd1nMLkGVveEd/SuZWgYTANUTIHEprpusbg==
+  dependencies:
+    "@opentelemetry/core" "0.25.0"
+    "@opentelemetry/resources" "0.25.0"
+    "@opentelemetry/sdk-trace-base" "0.25.0"
+    "@opentelemetry/semantic-conventions" "0.25.0"
 
 "@opentelemetry/exporter-zipkin@1.2.0":
   version "1.2.0"
@@ -1047,6 +1102,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/logfmt@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/logfmt/-/logfmt-1.2.1.tgz#981f9821464fc4a82a0aa2884b9c03d90c23ad99"
+  integrity sha512-kBeA+qbJAoyhIHBCOKEQYRDKPYyvt2m77cl1ZJUGfig8f5kgXZ7KOlPBN3/5whkwkK4nm47GN0bzdeObMWoYXQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/logfmt@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/logfmt/-/logfmt-1.2.2.tgz#80b0b824199b2bb29f9667d016b0ddbe469b04e1"
@@ -1085,6 +1147,16 @@
   version "17.0.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.30.tgz#2c6e8512acac70815e8176aa30c38025067880ef"
   integrity sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw==
+
+"@types/node@15.6.1":
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
+  integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
+
+"@types/node@16.7.2":
+  version "16.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.2.tgz#0465a39b5456b61a04d98bd5545f8b34be340cb7"
+  integrity sha512-TbG4TOx9hng8FKxaVrCisdaxKxqEwJ3zwHoCWXZ0Jw6mnvTInpaB99/2Cy4+XxpXtjNv9/TgfGSvZFyfV/t8Fw==
 
 "@types/node@17.0.31":
   version "17.0.31"
@@ -3643,11 +3715,6 @@ next@12.1.5:
     "@next/swc-win32-arm64-msvc" "12.1.5"
     "@next/swc-win32-ia32-msvc" "12.1.5"
     "@next/swc-win32-x64-msvc" "12.1.5"
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@2.6.7:
   version "2.6.7"


### PR DESCRIPTION
## Description

This PR updates `node-fetch` to the last possible version for now.

This PR try to fix the release name for the docker test because `/` in the name are messing with tests (see https://app.circleci.com/pipelines/github/fewlinesco/node-web-libraries/724/workflows/10952c27-560b-4dd8-8ce7-41b96f1b22a6/jobs/4619)

## Types of changes

- [ ] Chore (non-breaking change which refactors / improves the existing code base)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to a package version.
- [x] I have updated the `package.json` version accordingly.
- [x] I have updated the `CHANGELOG.md` version accordingly.
- [x] I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/node-web-libraries/blob/master/CONTRIBUTING.md
